### PR TITLE
Add Serialise instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,6 @@ matrix:
     - compiler: "ghc-7.8.4"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.8.4], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.6.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.6.3], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.4.2"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.4.2], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/base64-bytestring-type.cabal
+++ b/base64-bytestring-type.cabal
@@ -52,6 +52,7 @@ library
     , base64-bytestring  >=1.0.0.1  && <1.1
     , cereal             >=0.5.5.0  && <0.6
     , hashable           >=1.2.6.1  && <1.3
+    , serialise          >=0.2.0.0  && <0.3
     , QuickCheck         >=2.11.3   && <2.13
 
   if !impl(ghc >= 8.0)

--- a/src/Data/ByteString/Base64/Lazy/Type.hs
+++ b/src/Data/ByteString/Base64/Lazy/Type.hs
@@ -16,6 +16,7 @@ module Data.ByteString.Base64.Lazy.Type (
 import Prelude ()
 import Prelude.Compat
 
+import Codec.Serialise         (Serialise (..))
 import Control.DeepSeq         (NFData (..))
 import Data.Aeson
        (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), withText)
@@ -146,6 +147,13 @@ instance FromJSONKey ByteString64 where
 
 -- | 'ByteString64' is serialised as 'ByteString'
 instance Serialize ByteString64
+
+-------------------------------------------------------------------------------
+-- serialise
+-------------------------------------------------------------------------------
+
+-- | 'ByteString64' is serialised as 'ByteString'
+instance Serialise ByteString64
 
 -------------------------------------------------------------------------------
 -- binary

--- a/src/Data/ByteString/Base64/Type.hs
+++ b/src/Data/ByteString/Base64/Type.hs
@@ -15,6 +15,7 @@ module Data.ByteString.Base64.Type (
 import Prelude ()
 import Prelude.Compat
 
+import Codec.Serialise    (Serialise (..))
 import Control.DeepSeq    (NFData (..))
 import Data.Aeson
        (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), withText)
@@ -135,6 +136,13 @@ instance FromJSONKey ByteString64 where
 
 -- | 'ByteString64' is serialised as 'ByteString'
 instance Serialize ByteString64
+
+-------------------------------------------------------------------------------
+-- serialise
+-------------------------------------------------------------------------------
+
+-- | 'ByteString64' is serialised as 'ByteString'
+instance Serialise ByteString64
 
 -------------------------------------------------------------------------------
 -- binary

--- a/src/Data/ByteString/Base64/URL/Lazy/Type.hs
+++ b/src/Data/ByteString/Base64/URL/Lazy/Type.hs
@@ -16,6 +16,7 @@ module Data.ByteString.Base64.URL.Lazy.Type (
 import Prelude ()
 import Prelude.Compat
 
+import Codec.Serialise         (Serialise (..))
 import Control.DeepSeq         (NFData (..))
 import Data.Aeson
        (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), withText)
@@ -146,6 +147,13 @@ instance FromJSONKey ByteString64 where
 
 -- | 'ByteString64' is serialised as 'ByteString'
 instance Serialize ByteString64
+
+-------------------------------------------------------------------------------
+-- serialise
+-------------------------------------------------------------------------------
+
+-- | 'ByteString64' is serialised as 'ByteString'
+instance Serialise ByteString64
 
 -------------------------------------------------------------------------------
 -- binary

--- a/src/Data/ByteString/Base64/URL/Type.hs
+++ b/src/Data/ByteString/Base64/URL/Type.hs
@@ -15,6 +15,7 @@ module Data.ByteString.Base64.URL.Type (
 import Prelude ()
 import Prelude.Compat
 
+import Codec.Serialise    (Serialise (..))
 import Control.DeepSeq    (NFData (..))
 import Data.Aeson
        (FromJSON (..), FromJSONKey (..), ToJSON (..), ToJSONKey (..), withText)
@@ -132,6 +133,13 @@ instance FromJSONKey ByteString64 where
 
 -- | 'ByteString64' is serialised as 'ByteString'
 instance Serialize ByteString64
+
+-------------------------------------------------------------------------------
+-- serialise
+-------------------------------------------------------------------------------
+
+-- | 'ByteString64' is serialised as 'ByteString'
+instance Serialise ByteString64
 
 -------------------------------------------------------------------------------
 -- binary


### PR DESCRIPTION
This adds instances from the [serialise](http://hackage.haskell.org/package/serialise) package, making it suitable in more places that `ByteString`s are.