### PR TITLE
Make it build with ghc 9.10

### DIFF
--- a/base64-bytestring-type.cabal
+++ b/base64-bytestring-type.cabal
@@ -62,7 +62,7 @@ library
   -- boot libraries
   -- https://ghc.haskell.org/trac/ghc/wiki/Commentary/Libraries/VersionHistory
   build-depends:
-      base        >=4.7.0.0  && <4.20
+      base        >=4.7.0.0  && <4.21
     , binary      >=0.7.1.0  && <0.10
     , bytestring  >=0.10.4.0 && <0.13
     , deepseq     >=1.3.0.2  && <1.6
@@ -71,10 +71,10 @@ library
   -- other dependencies:
   build-depends:
       aeson              >=1.2.3.0 && <1.6 || >=2.0 && <2.3
-    , base-compat        >=0.9.3   && <0.14
+    , base-compat        >=0.9.3   && <0.15
     , base64-bytestring  >=1.0.0.1 && <1.3
     , hashable           >=1.2.6.1 && <1.5
-    , QuickCheck         >=2.11.3  && <2.15
+    , QuickCheck         >=2.11.3  && <2.16
 
   if !impl(ghc >=8.0)
     build-depends: semigroups >=0.18.5 && <0.21

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,15 @@
 packages: .
+
+
+source-repository-package
+  type: git
+  location: https://github.com/erikd/cborg
+  tag: 01f32360e2a3945a76e36ed9989e586f55675286
+  subdir:
+    cborg
+    serialise
+
+source-repository-package
+  type: git
+  location: https://github.com/erikd/http-api-data
+  tag: 27524abf3a4d11250b7affff847ae871e902b987


### PR DESCRIPTION
This commit requires the use of a couple of `source-repository-package` stanzas in the `cabal.project` file. These need to be removed before this can be merged.