### PR TITLE
Preliminary ghc-9.14 support

### DIFF
--- a/base64-bytestring-type.cabal
+++ b/base64-bytestring-type.cabal
@@ -64,7 +64,7 @@ library
   -- boot libraries
   -- https://ghc.haskell.org/trac/ghc/wiki/Commentary/Libraries/VersionHistory
   build-depends:
-      base        >=4.7.0.0  && <4.22
+      base        >=4.7.0.0  && <4.23
     , binary      >=0.7.1.0  && <0.10
     , bytestring  >=0.10.4.0 && <0.13
     , deepseq     >=1.3.0.2  && <1.6

--- a/cabal.project
+++ b/cabal.project
@@ -1,23 +1,46 @@
 packages: .
 
-if impl (ghc >= 9.12)
+if impl (ghc >= 9.14)
   allow-newer:
+    , aeson:containers
+    , aeson:template-haskell
     , assoc:base
+    , bifunctors:template-haskell
     , cborg:base
-    , containers:base
+    , cborg:containers
     , data-fix:base
+    , generically:base
     , hashable:base
+    , hashable:containers
+    , hashable:ghc-bignum
     , http-api-data:base
+    , http-api-data:containers
     , indexed-traversable:base
+    , indexed-traversable:containers
     , indexed-traversable-instances:base
     , integer-conversion:base
     , integer-logarithms:base
+    , integer-logarithms:ghc-bignum
     , OneTuple:base
+    , primitive:base
     , scientific:base
+    , scientific:containers
+    , scientific:template-haskell
     , semialign:base
+    , semialign:containers
     , serialise:base
+    , serialise:containers
     , splitmix:base
+    , tagged:template-haskell
+    , text:base
     , text-short:base
+    , text-short:template-haskell
+    , th-abstraction:template-haskell
+    , th-compat:template-haskell
     , these:base
     , time-compat:base
-    , unix:base
+    , unordered-containers:template-haskell
+    , uuid-types:template-haskell
+    , vector:base
+    , vector-stream:base
+    , witherable:containers

--- a/src/Data/ByteString/Base64/Lazy/Type.hs
+++ b/src/Data/ByteString/Base64/Lazy/Type.hs
@@ -22,7 +22,7 @@ import Data.Aeson
 import Data.Aeson.Types        (FromJSONKeyFunction (..), toJSONKeyText)
 import Data.Binary             (Binary (..))
 import Data.ByteString.Lazy    (ByteString, pack, unpack)
-import Data.Data               (Data, Typeable)
+import Data.Data               (Data)
 import Data.Hashable           (Hashable)
 import Data.Semigroup          (Semigroup (..))
 import Data.String             (IsString (..))
@@ -67,7 +67,7 @@ import Codec.Serialise (Serialise (..))
 -- "\"YWG/\""
 --
 newtype ByteString64 = BS64 ByteString
-    deriving (Eq, Ord, Data, Typeable, Generic)
+    deriving (Eq, Ord, Data, Generic)
 
 instance Show ByteString64 where
     showsPrec d (BS64 bs) = showParen (d > 10) $ showString "mkBS64 " . showsPrec 11 bs

--- a/src/Data/ByteString/Base64/Type.hs
+++ b/src/Data/ByteString/Base64/Type.hs
@@ -22,7 +22,7 @@ import Data.Aeson
 import Data.Aeson.Types   (FromJSONKeyFunction (..), toJSONKeyText)
 import Data.Binary        (Binary (..))
 import Data.ByteString    (ByteString, pack, unpack)
-import Data.Data          (Data, Typeable)
+import Data.Data          (Data)
 import Data.Hashable      (Hashable)
 import Data.Semigroup     (Semigroup (..))
 import Data.String        (IsString (..))
@@ -71,7 +71,7 @@ import Web.HttpApiData (FromHttpApiData (..), ToHttpApiData (..))
 -- "\"YWG/\""
 --
 newtype ByteString64 = BS64 ByteString
-    deriving (Eq, Ord, Data, Typeable, Generic)
+    deriving (Eq, Ord, Data, Generic)
 
 instance Show ByteString64 where
     showsPrec d (BS64 bs) = showParen (d > 10) $ showString "mkBS64 " . showsPrec 11 bs

--- a/src/Data/ByteString/Base64/URL/Lazy/Type.hs
+++ b/src/Data/ByteString/Base64/URL/Lazy/Type.hs
@@ -22,7 +22,7 @@ import Data.Aeson
 import Data.Aeson.Types        (FromJSONKeyFunction (..), toJSONKeyText)
 import Data.Binary             (Binary (..))
 import Data.ByteString.Lazy    (ByteString, pack, unpack)
-import Data.Data               (Data, Typeable)
+import Data.Data               (Data)
 import Data.Hashable           (Hashable)
 import Data.Semigroup          (Semigroup (..))
 import Data.String             (IsString (..))
@@ -67,7 +67,7 @@ import Codec.Serialise (Serialise (..))
 -- "\"YWG_\""
 --
 newtype ByteString64 = BS64 ByteString
-    deriving (Eq, Ord, Data, Typeable, Generic)
+    deriving (Eq, Ord, Data, Generic)
 
 instance Show ByteString64 where
     showsPrec d (BS64 bs) = showParen (d > 10) $ showString "mkBS64 " . showsPrec 11 bs

--- a/src/Data/ByteString/Base64/URL/Type.hs
+++ b/src/Data/ByteString/Base64/URL/Type.hs
@@ -22,7 +22,7 @@ import Data.Aeson
 import Data.Aeson.Types   (FromJSONKeyFunction (..), toJSONKeyText)
 import Data.Binary        (Binary (..))
 import Data.ByteString    (ByteString, pack, unpack)
-import Data.Data          (Data, Typeable)
+import Data.Data          (Data)
 import Data.Hashable      (Hashable)
 import Data.Semigroup     (Semigroup (..))
 import Data.String        (IsString (..))
@@ -71,7 +71,7 @@ import Web.HttpApiData (FromHttpApiData (..), ToHttpApiData (..))
 -- "\"YWG_\""
 --
 newtype ByteString64 = BS64 ByteString
-    deriving (Eq, Ord, Data, Typeable, Generic)
+    deriving (Eq, Ord, Data, Generic)
 
 instance Show ByteString64 where
     showsPrec d (BS64 bs) = showParen (d > 10) $ showString "mkBS64 " . showsPrec 11 bs


### PR DESCRIPTION
Typeable instances have been automatically derived since at least ghc-8.6.